### PR TITLE
Allows portable machines to be mounted on any turf that can have cables.

### DIFF
--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -464,7 +464,7 @@
 // return a knot cable (O-X) if one is present in the turf
 // null if there's none
 /turf/proc/get_cable_node()
-	if(!istype(src, /turf/simulated/floor))
+	if(!src.cancable)
 		return null
 	for(var/obj/structure/cable/C in src)
 		if(C.d1 == 0)


### PR DESCRIPTION
Couldn't wire singularity beacon on a catwalk, this fixes that and probably others.