### PR TITLE
Fixes several zero amount stack bugs.

### DIFF
--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -62,6 +62,7 @@
 	if(!user.IsAdvancedToolUser())
 		user << "<span class='danger'>You don't have the dexterity to do this!</span>"
 		return 0
+	if(zero_amount())	return 0
 	var/title = "Sheet-Glass"
 	title += " ([src.get_amount()] sheet\s left)"
 	switch(alert(title, "Would you like full tile glass or one direction?", "One Direction", "Full Window", "Cancel", null))

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -173,17 +173,24 @@
 	return 1
 
 /obj/item/stack/proc/use(var/used) // return 0 = borked; return 1 = had enough
+	if(zero_amount())
+		return 0
 	if (is_cyborg)
 		return source.use_charge(used * cost)
 	if (amount < used)
 		return 0
 	amount -= used
-	if (amount <= 0)
+	zero_amount()
+	update_icon()
+	return 1
+
+/obj/item/stack/proc/zero_amount()
+	if (amount < 1)
 		if(usr)
 			usr.unEquip(src, 1)
 		qdel(src)
-	update_icon()
-	return 1
+		return 1
+	return 0
 
 /obj/item/stack/proc/add(var/amount)
 	if (is_cyborg)
@@ -210,6 +217,7 @@
 
 /obj/item/stack/attack_hand(mob/user as mob)
 	if (user.get_inactive_hand() == src)
+		if(zero_amount())	return
 		var/obj/item/stack/F = new src.type( user, 1)
 		F.copy_evidences(src)
 		user.put_in_hands(F)
@@ -225,6 +233,7 @@
 /obj/item/stack/attackby(obj/item/W as obj, mob/user as mob, params)
 
 	if (istype(W, src.type))
+		if(zero_amount())	return
 		var/obj/item/stack/S = W
 		if (S.is_cyborg)
 			var/to_transfer = min(src.amount, round((S.source.max_energy - S.source.energy) / S.cost))

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -171,7 +171,8 @@
 			if(out.amount >= 1)
 				inp.amount -= out.amount
 				unload_mineral(out)
-			inp.zero_amount()
+			if(inp.amount < 1)
+				stack_list -= text2path(href_list["release"])
 		else
 			usr << "<span class='warning'>Required access not found.</span>"
 	if(href_list["plasteel"])

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -171,6 +171,7 @@
 			if(out.amount >= 1)
 				inp.amount -= out.amount
 				unload_mineral(out)
+			inp.zero_amount()
 		else
 			usr << "<span class='warning'>Required access not found.</span>"
 	if(href_list["plasteel"])


### PR DESCRIPTION
Fixes  #8357.
Fixes being able to use zero amount glass sheet stacks to construct one side windows.
Fixes the ore redemption machine dropping zero amount stacks when deconstructed.