### PR TITLE
Buffs airlock crushing.

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -31,7 +31,7 @@
 #define AGE_MAX				85	//oldest a character can be
 #define SHOES_SLOWDOWN		0	//How much shoes slow you down by default. Negative values speed you up
 #define POCKET_STRIP_DELAY			40	//time taken (in deciseconds) to search somebody's pockets
-#define DOOR_CRUSH_DAMAGE	10	//the amount of damage that airlocks deal when they crush you
+#define DOOR_CRUSH_DAMAGE	15	//the amount of damage that airlocks deal when they crush you
 
 #define	HUNGER_FACTOR		0.1	//factor at which mob nutrition decreases
 #define	REAGENTS_METABOLISM 0.4	//How many units of reagent are consumed per tick, by default.


### PR DESCRIPTION
~~Doubled crushing damage and added a chance to knock the victims unconscious to prevent baby screaming.~~

Increased crush damage to 15.

Fixes https://github.com/tgstation/-tg-station/issues/8862