### PR TITLE
Player notes notifications.

### DIFF
--- a/code/modules/admin/player_notes.dm
+++ b/code/modules/admin/player_notes.dm
@@ -71,7 +71,10 @@
 	if(lognote)//don't need an admin log for the notes applied automatically during bans.
 		message_admins("[key_name(usr)] added note '[note]' to [ckey]")
 		log_admin("[key_name(usr)] added note '[note]' to [ckey]")
-
+		var/mob/player = get_mob_by_ckey(ckey)
+		if(player)
+			player << "<span class='danger'>An admin has created a note about you.</span>"
+			player << 'sound/effects/adminhelp.ogg'
 	return
 
 //handles removing entries from the buffer, or removing the entire directory if no start_index is given


### PR DESCRIPTION
I feel it's very shitty that players have no idea when notes are created about them. If an admin does not have the decency to tell the player he got a new note, the player will never know and will never think to correct his behavior. Players can also feel some notes are unjust and they have no way of knowing they exist and will not be able to defend themselves.

So I added a bwoink for when a player note is created. The player in question will be notified about it ~~and will be able to read the note itself~~. The name of the admin who created the note is not revealed.

![gg](https://cloud.githubusercontent.com/assets/4951579/8421013/1d789f2c-1ec1-11e5-9121-341b53adcb88.png)