### PR TITLE
Added ability for items inside items to have action buttons.

### DIFF
--- a/code/_onclick/hud/action.dm
+++ b/code/_onclick/hud/action.dm
@@ -14,7 +14,7 @@
 	var/name = "Generic Action"
 	var/action_type = AB_ITEM
 	var/procname = null
-	var/atom/movable/target = null
+	var/obj/item/target = null
 	var/check_flags = 0
 	var/processing = 0
 	var/active = 0
@@ -104,7 +104,7 @@
 		if(owner.stat)
 			return 0
 	if(check_flags & AB_CHECK_INSIDE)
-		if(!(target in owner))
+		if(!(target in owner) && !(target.action_button_internal))
 			return 0
 	return 1
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -26,6 +26,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 	//If this is set, The item will make an action button on the player's HUD when picked up.
 	var/action_button_name //It is also the text which gets displayed on the action button. If not set it defaults to 'Use [name]'. If it's not set, there'll be no button.
 	var/action_button_is_hands_free = 0 //If 1, bypass the restrained, lying, and stunned checks action buttons normally test for
+	var/action_button_internal = 0 //If 1, bypass the inside check action buttons test for
 	var/datum/action/item_action/action = null
 
 	//Since any item can now be a piece of clothing, this has to be put here so all items share it.

--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -115,6 +115,8 @@
 	icon_state = "jetpack-void"
 	item_state =  "jetpack-void"
 	var/obj/item/weapon/tank/internals/tank = null
+	action_button_name = "Toggle Jetpack"
+	action_button_internal = 1
 
 /obj/item/weapon/tank/jetpack/suit/New()
 	..()

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -149,6 +149,16 @@
 				I.action.name = I.action_button_name
 				I.action.target = I
 			I.action.Grant(src)
+		for(var/obj/item/T in I)
+			if(T.action_button_name && T.action_button_internal)
+				if(!T.action)
+					if(T.action_button_is_hands_free)
+						T.action = new/datum/action/item_action/hands_free
+					else
+						T.action = new/datum/action/item_action
+					T.action.name = T.action_button_name
+					T.action.target = T
+				T.action.Grant(src)
 	return
 
 //this handles hud updates. Calls update_vision() and handle_hud_icons()


### PR DESCRIPTION
Resolves https://github.com/tgstation/-tg-station/issues/10322

I don't know if this is the best way to do it. I tested the case I wanted to work and existing action buttons (including spells and mime buttons) and everything works.