### PR TITLE
Fixed gases deleting all overlays of a turf when spreading.

### DIFF
--- a/code/LINDA/LINDA_turf_tile.dm
+++ b/code/LINDA/LINDA_turf_tile.dm
@@ -232,15 +232,13 @@
 	archived_cycle = SSair.times_fired
 
 /turf/simulated/proc/update_visuals(datum/gas_mixture/model)
-	overlays.Cut()
-	var/siding_icon_state = return_siding_icon_state()
-	if(siding_icon_state)
-		overlays += image('icons/turf/floors.dmi',siding_icon_state)
+	overlays -= SSair.plasma_overlay
+	overlays -= SSair.sleeptoxin_overlay
 	switch(model.graphic)
 		if("plasma")
-			overlays.Add(SSair.plasma_overlay)
+			overlays += SSair.plasma_overlay
 		if("sleeping_agent")
-			overlays.Add(SSair.sleeptoxin_overlay)
+			overlays += SSair.sleeptoxin_overlay
 
 /turf/simulated/proc/share_air(var/turf/simulated/T)
 	if(T.current_cycle < current_cycle)

--- a/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
@@ -9,6 +9,11 @@
 	smooth = 1
 	can_be_unanchored = 0
 	canSmoothWith = null
+	var/image/nest_overlay
+
+/obj/structure/stool/bed/nest/New()
+	nest_overlay = image('icons/mob/alien.dmi', "nestoverlay", layer=MOB_LAYER - 0.2)
+	return ..()
 
 /obj/structure/stool/bed/nest/user_unbuckle_mob(mob/user as mob)
 	if(buckled_mob && buckled_mob.buckled == src)
@@ -59,12 +64,12 @@
 		M.pixel_y = 0
 		M.pixel_x = initial(M.pixel_x) + 2
 		M.layer = MOB_LAYER - 0.3
-		overlays += image('icons/mob/alien.dmi', "nestoverlay", layer=MOB_LAYER - 0.2)
+		overlays += nest_overlay
 	else
 		M.pixel_x = M.get_standard_pixel_x_offset(M.lying)
 		M.pixel_y = M.get_standard_pixel_y_offset(M.lying)
 		M.layer = initial(M.layer)
-		overlays.Cut()
+		overlays -= nest_overlay
 
 /obj/structure/stool/bed/nest/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
 	var/aforce = W.force

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -107,8 +107,6 @@
 
 /turf/proc/is_plasteel_floor()
 	return 0
-/turf/proc/return_siding_icon_state()		//used for grass floors, which have siding.
-	return 0
 
 /turf/proc/levelupdate()
 	for(var/obj/O in src)


### PR DESCRIPTION
Fixes https://github.com/tgstation/-tg-station/issues/10528

Also removed a proc that is no longer used.

E: Also fixes nests overlays being deleted when unbuckling a mob (meaning the nest would go invisible).