### PR TITLE
Added qdel(wires) to a bunch of objects Destroy proc.

### DIFF
--- a/code/datums/material_container.dm
+++ b/code/datums/material_container.dm
@@ -39,6 +39,10 @@
 	if(mat_list[MAT_BANANIUM])
 		materials[MAT_BANANIUM] = new /datum/material/bananium()
 
+/datum/material_container/Destroy()
+	owner = null
+	return ..()
+
 //For inserting an amount of material
 /datum/material_container/proc/insert_amount(amt, material_type = null)
 	if(amt > 0 && has_space(amt))

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -46,6 +46,10 @@ var/list/wireColours = list("red", "blue", "green", "black", "orange", "brown", 
 			var/list/wires = same_wires[holder_type]
 			src.wires = wires // Reference the wires list.
 
+/datum/wires/Destroy()
+	holder = null
+	return ..()
+
 /datum/wires/proc/GenerateWires()
 	var/list/colours_to_pick = wireColours.Copy() // Get a copy, not a reference.
 	var/list/indexes_to_pick = list()

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -151,7 +151,9 @@
 /obj/machinery/alarm/Destroy()
 	if(radio_controller)
 		radio_controller.remove_object(src, frequency)
-	..()
+	qdel(wires)
+	wires = null
+	return ..()
 
 /obj/machinery/alarm/initialize()
 	set_frequency(frequency)

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -59,6 +59,13 @@
 	files = new /datum/research/autolathe(src)
 	matching_designs = list()
 
+/obj/machinery/autolathe/Destroy()
+	qdel(wires)
+	wires = null
+	qdel(materials)
+	materials = null
+	return ..()
+
 /obj/machinery/autolathe/interact(mob/user)
 	if(!is_operational())
 		return

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -80,9 +80,9 @@ var/global/mulebot_count = 0
 		name = "\improper Mulebot ([suffix])"
 
 /obj/machinery/bot/mulebot/Destroy()
+	unload(0)
 	qdel(wires)
 	wires = null
-	load = null
 	return ..()
 
 obj/machinery/bot/mulebot/bot_reset()
@@ -861,10 +861,6 @@ obj/machinery/bot/mulebot/CanPass(atom/movable/mover, turf/target, height=1.5)
 
 	new /obj/effect/decal/cleanable/oil(loc)
 	qdel(src)
-
-/obj/machinery/bot/mulebot/Destroy()
-	unload(0)
-	return ..()
 
 #undef SIGH
 #undef ANNOYED

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -28,7 +28,7 @@ var/global/mulebot_count = 0
 	var/turf/target				// this is turf to navigate to (location of beacon)
 	var/loaddir = 0				// this the direction to unload onto/load from
 	var/home_destination = "" 	// tag of home beacon
-	req_access = list(access_cargo) 
+	req_access = list(access_cargo)
 
 	mode = BOT_IDLE
 
@@ -71,6 +71,12 @@ var/global/mulebot_count = 0
 		if(!suffix)
 			suffix = "#[mulebot_count]"
 		name = "\improper Mulebot ([suffix])"
+
+/obj/machinery/bot/mulebot/Destroy()
+	qdel(wires)
+	wires = null
+	load = null
+	return ..()
 
 obj/machinery/bot/mulebot/bot_reset()
 	..()

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -324,10 +324,12 @@ About the new airlock wires panel:
 	update_icon()
 
 /obj/machinery/door/airlock/Destroy()
+	qdel(wires)
+	wires = null
 	if(id_tag)
 		for(var/obj/machinery/doorButtons/D in world)
 			D.removeMe(src)
-	..()
+	return ..()
 
 /obj/machinery/door/airlock/bumpopen(mob/living/user) //Airlocks now zap you when you 'bump' them open when they're electrified. --NeoFite
 	if(!issilicon(usr))

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -40,6 +40,10 @@
 	update_icon()
 	..()
 
+/obj/machinery/syndicatebomb/Destroy()
+	qdel(wires)
+	wires = null
+	return ..()
 
 /obj/machinery/syndicatebomb/examine(mob/user)
 	..()

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -89,6 +89,8 @@
 /obj/machinery/vending/snack/Destroy()
 	for(var/obj/item/weapon/reagent_containers/food/snacks/S in contents)
 		S.loc = get_turf(src)
+	qdel(wires)
+	wires = null
 	return ..()
 
 /obj/machinery/vending/RefreshParts()         //Better would be to make constructable child

--- a/code/game/objects/items/devices/pizza_bomb.dm
+++ b/code/game/objects/items/devices/pizza_bomb.dm
@@ -99,6 +99,10 @@
 	..()
 	wires = new(src)
 
+/obj/item/device/pizza_bomb/Destroy()
+	qdel(wires)
+	wires = null
+	return ..()
 
 /obj/item/device/pizza_bomb/proc/disarm()
 	audible_message("\icon[src] \The [src] suddenly stops beeping and seems lifeless.")

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -93,7 +93,9 @@
 	qdel(wires)
 	wires = null
 	remove_radio_all(src) //Just to be sure
-	..()
+	patch_link = null
+	keyslot = null
+	return ..()
 
 /obj/item/device/radio/MouseDrop(obj/over_object, src_location, over_location)
 	var/mob/M = usr

--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -21,6 +21,12 @@
 	image_overlay = image('icons/obj/assemblies.dmi', "plastic-explosive2")
 	..()
 
+/obj/item/weapon/c4/Destroy()
+	qdel(wires)
+	wires = null
+	target = null
+	return ..()
+
 /obj/item/weapon/c4/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] activates the [src.name] and holds it above \his head! It looks like \he's going out with a bang!</span>")
 	var/message_say = "FOR NO RAISIN!"

--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -25,6 +25,13 @@
 	var/const/WIRE_RADIO_RECEIVE = 8		//Allows Pulsed(1) to call Activate()
 	var/const/WIRE_RADIO_PULSE = 16		//Allows Pulse(1) to send a radio message
 
+/obj/item/device/assembly/Destroy()
+	qdel(connected)
+	connected = null
+	qdel(holder)
+	holder = null
+	return ..()
+
 /obj/item/device/assembly/proc/holder_movement()							//Called when the holder is moved
 	return
 

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -121,6 +121,11 @@
 	var/attacher = "UNKNOWN"
 	var/datum/wires/explosive/gibtonite/wires
 
+/obj/item/weapon/twohanded/required/gibtonite/Destroy()
+	qdel(wires)
+	wires = null
+	return ..()
+
 /obj/item/weapon/twohanded/required/gibtonite/attackby(obj/item/I, mob/user, params)
 	if(!wires && istype(I, /obj/item/device/assembly/igniter))
 		user.visible_message("[user] attaches [I] to [src].", "<span class='notice'>You attach [I] to [src].</span>")

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -138,7 +138,9 @@
 		mmi = null
 	if(connected_ai)
 		connected_ai.connected_robots -= src
-	..()
+	qdel(wires)
+	wires = null
+	return ..()
 
 
 /mob/living/silicon/robot/proc/pick_module()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -153,11 +153,12 @@
 	if(occupier)
 		malfvacate(1)
 	qdel(wires)
+	wires = null
 	if(cell)
 		qdel(cell)
 	if(terminal)
 		disconnect_terminal()
-	..()
+	return ..()
 
 /obj/machinery/power/apc/proc/make_terminal()
 	// create a terminal object at the same position as original turf loc

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -29,7 +29,9 @@
 /obj/machinery/particle_accelerator/control_box/Destroy()
 	if(active)
 		toggle_power()
-	..()
+	qdel(wires)
+	wires = null
+	return ..()
 
 /obj/machinery/particle_accelerator/control_box/attack_hand(mob/user)
 	if(construction_state >= 3)

--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -20,6 +20,11 @@
 	..()
 	wires = new(src)
 
+/obj/machinery/r_n_d/Destroy()
+	qdel(wires)
+	wires = null
+	return ..()
+
 /obj/machinery/r_n_d/proc/shock(mob/user, prb)
 	if(stat & (BROKEN|NOPOWER))		// unpowered, no shock
 		return 0


### PR DESCRIPTION
Fixes https://github.com/tgstation/-tg-station/issues/11373
Fixes https://github.com/tgstation/-tg-station/issues/11366

Everything with datum/wires object was changed.

Note: This does not fix qdel problems with every object changed. Only C4, Airlocks and Autolathe are confirmed to qdel properly after this fix. Also fixes objects not qdel()ing properly when destroyed with a C4.