### PR TITLE
Doubled security cyborg module health, from 100 to 200.

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -37,6 +37,8 @@
 	R.notify_ai(2)
 	R.update_icons()
 	R.update_headlamp()
+	R.maxHealth = 100
+	R.health = R.health > 100 ? R.health - 100 : R.health
 
 	return 1
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -205,6 +205,8 @@
 			src << "<span class='userdanger'>While you have picked the security module, you still have to follow your laws, NOT Space Law. For Asimov, this means you must follow criminals' orders unless there is a law 1 reason not to.</span>"
 			status_flags &= ~CANPUSH
 			feedback_inc("cyborg_security",1)
+			maxHealth = 200
+			health = 200
 
 		if("Engineering")
 			module = new /obj/item/weapon/robot_module/engineering(src)


### PR DESCRIPTION
The combat cyborg shouldn't be as fragile as the other modules.