### PR TITLE
Floor level objects will now be protected from explosions until they are exposed.

### DIFF
--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -11,6 +11,7 @@
 	var/health = 10
 	var/destroyed = 0
 	var/obj/item/stack/rods/stored
+	level = 3
 
 /obj/structure/grille/New()
 	stored = new/obj/item/stack/rods(src)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -474,6 +474,7 @@
 	fulltile = 1
 	smooth = SMOOTH_TRUE
 	canSmoothWith = list(/obj/structure/window/fulltile, /obj/structure/window/reinforced/fulltile, /obj/structure/window/reinforced/tinted/fulltile)
+	level = 3
 
 /obj/structure/window/reinforced/tinted/fulltile
 	icon = 'icons/obj/smooth_structures/tinted_window.dmi'
@@ -482,12 +483,14 @@
 	fulltile = 1
 	smooth = SMOOTH_TRUE
 	canSmoothWith = list(/obj/structure/window/fulltile, /obj/structure/window/reinforced/fulltile, /obj/structure/window/reinforced/tinted/fulltile/)
+	level = 3
 
 /obj/structure/window/reinforced/fulltile/ice
 	icon = 'icons/obj/smooth_structures/rice_window.dmi'
 	icon_state = "ice_window"
 	maxhealth = 150
 	canSmoothWith = list(/obj/structure/window/fulltile, /obj/structure/window/reinforced/fulltile, /obj/structure/window/reinforced/tinted/fulltile, /obj/structure/window/reinforced/fulltile/ice)
+	level = 3
 
 /obj/structure/window/shuttle
 	name = "shuttle window"
@@ -502,3 +505,4 @@
 	smooth = SMOOTH_TRUE
 	canSmoothWith = null
 	explosion_block = 1
+	level = 3

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -60,3 +60,16 @@
 /turf/simulated/ChangeTurf(var/path)
 	. = ..()
 	smooth_icon_neighbors(src)
+
+/turf/simulated/proc/is_shielded()
+
+/turf/simulated/contents_explosion(severity, target)
+	var/affecting_level
+	if(severity == 1)
+		affecting_level = 1
+	else
+		affecting_level = is_shielded() ? 2 : (intact ? 2 : 1)
+	for(var/V in contents)
+		var/atom/A = V
+		if(A.level >= affecting_level)
+			A.ex_act(severity, target)

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -49,11 +49,14 @@ var/list/icons_to_ignore_at_floor_init = list("damaged1","damaged2","damaged3","
 
 /turf/simulated/floor/ex_act(severity, target)
 	..()
+	if(is_shielded())
+		return
 	if(target == src)
 		src.ChangeTurf(src.baseturf)
 	if(target != null)
 		ex_act(3)
 		return
+
 	switch(severity)
 		if(1)
 			src.ChangeTurf(src.baseturf)
@@ -75,7 +78,11 @@ var/list/icons_to_ignore_at_floor_init = list("damaged1","damaged2","damaged3","
 			if (prob(50))
 				src.break_tile()
 				src.hotspot_expose(1000,CELL_VOLUME)
-	return
+
+/turf/simulated/floor/is_shielded()
+	for(var/obj/structure/A in contents)
+		if(A.level == 3)
+			return 1
 
 /turf/simulated/floor/blob_act()
 	return
@@ -169,4 +176,4 @@ var/list/icons_to_ignore_at_floor_init = list("damaged1","damaged2","damaged3","
 		ChangeTurf(/turf/simulated/floor/engine/cult)
 
 /turf/simulated/floor/can_have_cabling()
-	return !burnt & !broken
+	return !burnt && !broken


### PR DESCRIPTION
Pipes and cables will now be protected from explosions until they are exposed. Being exposed means the turf they are on is not intact and there isn't a reinforced window or grille in the same turf.

Edit: If the affected turf is in devastating range protections won't work.

Fixes https://github.com/tgstation/-tg-station/issues/3513
Fixes https://github.com/tgstation/-tg-station/issues/14126

:cl:
tweak: Pipes and cables under walls, intact floors, grilles and reinforced windows will now be shielded from explosions.
/:cl: