### PR TITLE
Added a "no power" warning emote to cyborgs.

### DIFF
--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -5,7 +5,6 @@
 		param = copytext(act, t1 + 1, length(act) + 1)
 		act = copytext(act, 1, t1)
 
-
 	switch(act)//01000001011011000111000001101000011000010110001001100101011101000110100101111010011001010110010000100001 (Seriously please keep it that way.)
 		if ("aflap")
 			if (!src.restrained())
@@ -240,3 +239,14 @@
 		else
 			audible_message(message)
 	return
+
+/mob/living/silicon/robot/verb/powerwarn()
+	set category = "Robot Commands"
+	set name = "Power Warning"
+
+	if(!cell.charge)
+		visible_message("The power warning light on <span class='name'>[src]</span> flashes urgently.",\
+						 "You announce you are operating in low power mode.")
+		playsound(loc, 'sound/machines/buzz-two.ogg', 50, 0)
+	else
+		src << "<span class='warning'>You can only use this emote when you're out of charge.</span>"


### PR DESCRIPTION
Closes https://github.com/tgstation/-tg-station/issues/14938

:cl:
rscadd: Added a no power warning cyborg verb to Robot Commands.
/:cl: