### PR TITLE
Map merger patch

### DIFF
--- a/tools/mapmerge/Run Map Merge.bat
+++ b/tools/mapmerge/Run Map Merge.bat
@@ -1,5 +1,5 @@
 @echo off
 set MAPROOT="../../_maps/"
-set TGM=1
+set TGM=0
 python mapmerger.py %1 %MAPROOT% %TGM%
 pause

--- a/tools/mapmerge/Run Map Merge.bat
+++ b/tools/mapmerge/Run Map Merge.bat
@@ -1,5 +1,5 @@
 @echo off
 set MAPROOT="../../_maps/"
-set TGM=0
+set TGM=1
 python mapmerger.py %1 %MAPROOT% %TGM%
 pause

--- a/tools/mapmerge/mapmerger.py
+++ b/tools/mapmerge/mapmerger.py
@@ -28,8 +28,10 @@ def main(map_folder, tgm=0):
 
     if tgm == "1":
         print("\nMaps will be converted to tgm.")
+        tgm = True
     else:
         print("\nMaps will not be converted to tgm.")
+        tgm = False
 
     print("\nMerging these maps:")
     for i in valid_indices:
@@ -42,11 +44,9 @@ def main(map_folder, tgm=0):
         for i in valid_indices:
             path_str = str(list_of_files[i])
             try:
-                if map_helpers.merge_map(path_str, path_str + ".backup") != 1:
+                if map_helpers.merge_map(path_str, path_str + ".backup", tgm) != 1:
                     print("ERROR MERGING: {}".format(list_of_files[i]))
                     continue
-                if tgm == "1":
-                    dmm2tgm.convert_map(path_str)
                 print("MERGED: {}".format(path_str))
             except FileNotFoundError:
                 print("\nERROR: File not found! Make sure you run 'Prepare Maps.bat' before merging.")


### PR DESCRIPTION
Fixes https://github.com/tgstation/-tg-station/issues/15715

Changed it so when the merger is ran in 'tgm' mode (default), the merged map will be written in tgm directly and with a custom map format (see https://gist.github.com/anonymous/3a3607baa60184ffd710). This new format avoids conflicts as much as possible.

What a map file will look like after being processed in 'tgm' mode:
"aYY" = (
/obj/machinery/atmospherics/pipe/simple/supply/hidden{
____dir = 4
____},
/turf/simulated/floor/carpet,
/area/library)

(127,1,1) = {"
aaa
aaa
aaa
aaa
aaa
aaa
aaa
aaa
aaa
aaa
...
aaa
"}
