### PR TITLE
Scrubber clog event now has a chance to spawn cockroaches.

### DIFF
--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -43,12 +43,7 @@
 			smoke.start()
 			qdel(R)
 
-			var/cockroaches = prob(20) ? 2 : 0
-			cockroaches += prob(10) ? 1 : 0
-			cockroaches += prob(10) ? 1 : 0
-			if(!cockroaches)
-				if(prob(1) && prob(1))
-					cockroaches = 10
+			var/cockroaches = prob(33) ? 3 : 0
 			while(cockroaches)
 				new /mob/living/simple_animal/cockroach(get_turf(vent))
 				cockroaches--

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -9,6 +9,8 @@
 	endWhen			= 35
 	var/interval 	= 2
 	var/list/vents  = list()
+	var/list/gunk = list("water","carbon","flour","radium","toxin","cleaner","nutriment","condensedcapsaicin","mushroomhallucinogen","lube",
+								 "plantbgone","banana","charcoal","space_drugs","morphine","holywater","ethanol","hot_coco","facid")
 
 /datum/round_event/vent_clog/announce()
 	priority_announce("The scrubbers network is experiencing a backpressure surge. Some ejection of contents may occur.", "Atmospherics alert")
@@ -26,10 +28,11 @@
 
 /datum/round_event/vent_clog/tick()
 	if(activeFor % interval == 0)
-		var/obj/vent = pick_n_take(vents)
+		var/obj/machinery/atmospherics/components/unary/vent = pick_n_take(vents)
+		while(vent && vent.welded)
+			vent = pick_n_take(vents)
+
 		if(vent && vent.loc)
-			var/list/gunk = list("water","carbon","flour","radium","toxin","cleaner","nutriment","condensedcapsaicin","mushroomhallucinogen","lube",
-								 "plantbgone","banana","charcoal","space_drugs","morphine","holywater","ethanol","hot_coco","facid")
 			var/datum/reagents/R = new/datum/reagents(50)
 			R.my_atom = vent
 			R.add_reagent(pick(gunk), 50)
@@ -39,3 +42,13 @@
 			playsound(vent.loc, 'sound/effects/smoke.ogg', 50, 1, -3)
 			smoke.start()
 			qdel(R)
+
+			var/cockroaches = prob(20) ? 2 : 0
+			cockroaches += prob(10) ? 1 : 0
+			cockroaches += prob(10) ? 1 : 0
+			if(!cockroaches)
+				if(prob(1) && prob(1))
+					cockroaches = 10
+			while(cockroaches)
+				new /mob/living/simple_animal/cockroach(get_turf(vent))
+				cockroaches--


### PR DESCRIPTION
An addition following the merging of https://github.com/tgstation/-tg-station/pull/15810

Cockroaches are ejected from scrubbers due to the back pressure. It turns out those pipes were home to resilient space cockroaches!

:cl:
rscadd: Scrubber clog event now ejects cockroaches.
/:cl:

Note: problem of sprites persists.
edit: New sprites were made.