### PR TITLE
Fixed and buffed the banana shoes

### DIFF
--- a/code/modules/clothing/shoes/bananashoes.dm
+++ b/code/modules/clothing/shoes/bananashoes.dm
@@ -24,6 +24,7 @@
 		bananium.use_amount_type(100, MAT_BANANIUM)
 		if(bananium.amount(MAT_BANANIUM) < 100)
 			on = !on
+			flags &= ~NOSLIP
 			update_icon()
 			loc << "<span class='warning'>You ran out of bananium!</span>"
 	else
@@ -37,8 +38,6 @@
 		user << "<span class='notice'>You cannot retrieve any bananium from the prototype shoes.</span>"
 
 /obj/item/clothing/shoes/clown_shoes/banana_shoes/attackby(obj/item/O, mob/user, params)
-	if(!istype(O,/obj/item/stack/sheet))
-		return
 	if(!bananium.get_item_material_amount(O))
 		user << "<span class='notice'>This item has no bananium!</span>"
 		return
@@ -46,10 +45,10 @@
 		user << "<span class='notice'>You can't drop [O]!</span>"
 		return
 
-	var/obj/item/stack/sheet/S = O
-	var/sheet_amount = bananium.insert_stack(O,S.amount)
-	if(sheet_amount)
-		user << "<span class='notice'>You insert [sheet_amount] bananium sheets into the prototype shoes.</span>"
+	var/bananium_amount = bananium.insert_item(O)
+	if(bananium_amount)
+		user << "<span class='notice'>You insert [O] into the prototype shoes.</span>"
+		qdel(O)
 	else
 		user << "<span class='notice'>You are unable to insert more bananium!</span>"
 
@@ -63,6 +62,10 @@
 		on = !on
 		update_icon()
 		user << "<span class='notice'>You [on ? "activate" : "deactivate"] the prototype shoes.</span>"
+		if(on)
+			flags |= NOSLIP
+		else
+			flags &= ~NOSLIP
 	else
 		user << "<span class='warning'>You need bananium to turn the prototype shoes on!</span>"
 

--- a/code/modules/hydroponics/grown/banana.dm
+++ b/code/modules/hydroponics/grown/banana.dm
@@ -114,5 +114,7 @@
 	desc = "A synthetic banana peel."
 
 /obj/item/weapon/grown/bananapeel/specialpeel/Crossed(AM)
-	if(..())
-		qdel(src)
+	if(iscarbon(AM))
+		var/mob/living/carbon/carbon = AM
+		if(carbon.slip(2, 2, src, FALSE))
+			qdel(src)


### PR DESCRIPTION
 - Fixed synthetic banana peels slipping for too long and not deleting themselves on slip
 - Banana shoes can now take any item that has bananium in it, instead of just refined sheets
 - Banana shoes have NOSLIP when turned on

:cl:
bugfix: Fixed the mk-honk prototype shoes.
/:cl: